### PR TITLE
fixes for using tablePrefix in tables and the index

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ class PostgresPersistenceEngine extends AbstractPersistenceEngine {
     this.db = pgp(connectionString);
     this.tablePrefix = tablePrefix;
     if (createIfNotExists) {
-      this.db.none(create(settings.tablePrefix)).catch(console.error);
+      this.db.none(create(tablePrefix)).catch(console.error);
     }
   }
 
@@ -52,7 +52,7 @@ class PostgresPersistenceEngine extends AbstractPersistenceEngine {
     assert(Number.isInteger(limit) || limit === null);
     assert(tags === undefined || (tags instanceof Array && tags.reduce((isStrArr, curr) => isStrArr && typeof (curr) === 'string', true)));
 
-    const query = ` SELECT * from ${this.tablePrefix}event_journal 
+    const query = ` SELECT * from ${this.tablePrefix}event_journal
                     WHERE persistence_key = $1
                     AND is_deleted = false
                     ${tags ? 'AND tags @> ($4::text[])' : ''}
@@ -67,13 +67,13 @@ class PostgresPersistenceEngine extends AbstractPersistenceEngine {
   }
 
   persist (persistedEvent) {
-    const query = ` 
-      INSERT INTO ${this.tablePrefix}event_journal (          
+    const query = `
+      INSERT INTO ${this.tablePrefix}event_journal (
         persistence_key,
-        sequence_nr,    
-        created_at,   
-        data,          
-        tags          
+        sequence_nr,
+        created_at,
+        data,
+        tags
       ) VALUES ($/key/, $/sequenceNumber/, $/createdAt/, $/data:json/, $/tags/)
       RETURNING ordering;
     `;
@@ -91,10 +91,10 @@ class PostgresPersistenceEngine extends AbstractPersistenceEngine {
   latestSnapshot (persistenceKey) {
     assert(typeof (persistenceKey) === 'string');
 
-    const query = ` SELECT * from ${this.tablePrefix}snapshot_store 
+    const query = ` SELECT * from ${this.tablePrefix}snapshot_store
     WHERE persistence_key = $1
-    AND is_deleted = false   
-    ORDER BY sequence_nr DESC    
+    AND is_deleted = false
+    ORDER BY sequence_nr DESC
     LIMIT 1
   `;
 
@@ -102,10 +102,10 @@ class PostgresPersistenceEngine extends AbstractPersistenceEngine {
   }
 
   takeSnapshot (persistedSnapshot) {
-    const query = ` INSERT INTO ${this.tablePrefix}snapshot_store (          
+    const query = ` INSERT INTO ${this.tablePrefix}snapshot_store (
           persistence_key,
-          sequence_nr,    
-          created_at,   
+          sequence_nr,
+          created_at,
           data
         )
         VALUES ($1, $2, $3, $4)

--- a/lib/schema/index.js
+++ b/lib/schema/index.js
@@ -2,22 +2,22 @@ module.exports.create = (tablePrefix = '') => `
   CREATE TABLE IF NOT EXISTS ${tablePrefix}event_journal (
     ordering BIGSERIAL NOT NULL PRIMARY KEY,
     persistence_key VARCHAR(255) NOT NULL,
-    sequence_nr BIGINT NOT NULL,    
-    created_at BIGINT NOT NULL,   
+    sequence_nr BIGINT NOT NULL,
+    created_at BIGINT NOT NULL,
     data JSONB NOT NULL,
-    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,    
+    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
     tags TEXT ARRAY DEFAULT ARRAY[]::TEXT[],
-    CONSTRAINT event_journal_uq UNIQUE (persistence_key, sequence_nr)
-  );  
+    CONSTRAINT ${tablePrefix}event_journal_uq UNIQUE (persistence_key, sequence_nr)
+  );
   CREATE TABLE IF NOT EXISTS ${tablePrefix}snapshot_store (
     ordering BIGSERIAL NOT NULL PRIMARY KEY,
     persistence_key VARCHAR(255) NOT NULL,
-    sequence_nr BIGINT NOT NULL,    
-    created_at BIGINT NOT NULL,   
+    sequence_nr BIGINT NOT NULL,
+    created_at BIGINT NOT NULL,
     data JSONB NOT NULL,
-    is_deleted BOOLEAN NOT NULL DEFAULT FALSE    
-  );  
+    is_deleted BOOLEAN NOT NULL DEFAULT FALSE
+  );
   `;
 
-module.exports.destroy = (tablePrefix = '') => `DROP TABLE IF EXISTS ${tablePrefix}event_journal CASCADE; 
+module.exports.destroy = (tablePrefix = '') => `DROP TABLE IF EXISTS ${tablePrefix}event_journal CASCADE;
 DROP TABLE IF EXISTS ${tablePrefix}snapshot_store CASCADE;`;


### PR DESCRIPTION
This patch makes sure that tablePrefix is properly used. 

I actually only changed two lines, but I see that my editor removed trailing spaces too - I hope that's not too confusing.