### PR TITLE
Update pg-promise dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "http://github.com/ncthbrt/nact-persistence-postgres/issues"
   },
   "dependencies": {
-    "pg-promise": "^8.4.0"
+    "pg-promise": "^10.6.1"
   },
   "devDependencies": {
     "chai": "^4.1.1",


### PR DESCRIPTION
pg-promise v8 sends a message on install that it's outdated. When I use the most recent 8.x version of pg-promise that is installed by this package, the connection to psql silently fails. Updating the dependency fixes the problem.