### PR TITLE
feat(): add optional schema and table names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE
+.idea
+
 # Logs
 logs
 *.log

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,16 +16,19 @@ class Result {
 }
 
 class PostgresPersistenceEngine extends AbstractPersistenceEngine {
-  constructor (connectionStringOrConnection, {createIfNotExists = true, tablePrefix = ''} = {}) {
+  constructor (connectionStringOrConnection, {createIfNotExists = true, tablePrefix = '', schema = null, eventTable = 'event_journal', snapshotTable = 'snapshot_store'} = {}) {
     super();
     this.tablePrefix = tablePrefix;
+    this.schema = schema;
+    this.eventTable = eventTable;
+    this.snapshotTable = snapshotTable;
     this.db = (async () => {
       let db = connectionStringOrConnection;
       if (typeof (connectionStringOrConnection) === 'string') {
         db = pgp()(connectionStringOrConnection);
       }
       if (createIfNotExists) {
-        await db.none(create(tablePrefix)).catch(console.error);
+        await db.none(create(tablePrefix, schema, eventTable, snapshotTable)).catch(console.error);
       }
       return db;
     })();
@@ -59,10 +62,10 @@ class PostgresPersistenceEngine extends AbstractPersistenceEngine {
     assert(Number.isInteger(limit) || limit === null);
     assert(tags === undefined || (tags instanceof Array && tags.reduce((isStrArr, curr) => isStrArr && typeof (curr) === 'string', true)));
 
-    const query = ` SELECT * from ${this.tablePrefix}event_journal
-                    WHERE persistence_key = $1 AND sequence_nr > $2                    
+    const query = ` SELECT * from ${this.schema ? this.schema + '.' : ''}${this.tablePrefix}${this.eventTable}
+                    WHERE persistence_key = $1 AND sequence_nr > $2
                     ${tags ? 'AND tags @> ($4::text[])' : ''}
-                    ORDER BY sequence_nr                    
+                    ORDER BY sequence_nr
                     LIMIT $3
                   `;
 
@@ -73,7 +76,7 @@ class PostgresPersistenceEngine extends AbstractPersistenceEngine {
 
   async persist (persistedEvent) {
     const query = `
-      INSERT INTO ${this.tablePrefix}event_journal (
+      INSERT INTO ${this.schema ? this.schema + '.' : ''}${this.tablePrefix}${this.eventTable} (
         persistence_key,
         sequence_nr,
         created_at,
@@ -96,7 +99,7 @@ class PostgresPersistenceEngine extends AbstractPersistenceEngine {
   async latestSnapshot (persistenceKey) {
     assert(typeof (persistenceKey) === 'string');
 
-    const query = ` SELECT * from ${this.tablePrefix}snapshot_store
+    const query = ` SELECT * from ${this.schema ? this.schema + '.' : ''}${this.tablePrefix}${this.snapshotTable}
     WHERE persistence_key = $1
     AND is_deleted = false
     ORDER BY sequence_nr DESC
@@ -107,7 +110,7 @@ class PostgresPersistenceEngine extends AbstractPersistenceEngine {
   }
 
   async takeSnapshot (persistedSnapshot) {
-    const query = ` INSERT INTO ${this.tablePrefix}snapshot_store (
+    const query = ` INSERT INTO ${this.schema ? this.schema + '.' : ''}${this.tablePrefix}${this.snapshotTable} (
           persistence_key,
           sequence_nr,
           created_at,

--- a/lib/schema/index.js
+++ b/lib/schema/index.js
@@ -1,23 +1,48 @@
-module.exports.create = (tablePrefix) => `
-  CREATE TABLE IF NOT EXISTS ${tablePrefix}event_journal (
-    ordering BIGSERIAL NOT NULL PRIMARY KEY,
-    persistence_key VARCHAR(255) NOT NULL,
-    sequence_nr BIGINT NOT NULL,
-    created_at BIGINT NOT NULL,
-    data JSONB NOT NULL,
-    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
-    tags TEXT ARRAY DEFAULT ARRAY[]::TEXT[],
-    CONSTRAINT ${tablePrefix}event_journal_uq UNIQUE (persistence_key, sequence_nr)
-  );
-  CREATE TABLE IF NOT EXISTS ${tablePrefix}snapshot_store (
-    ordering BIGSERIAL NOT NULL PRIMARY KEY,
-    persistence_key VARCHAR(255) NOT NULL,
-    sequence_nr BIGINT NOT NULL,
-    created_at BIGINT NOT NULL,
-    data JSONB NOT NULL,
-    is_deleted BOOLEAN NOT NULL DEFAULT FALSE
-  );
+module.exports.create = (tablePrefix, schema = null, eventTable = 'event_journal', snapshotTable = 'snapshot_store') => {
+  const schemaQuery = `
+    CREATE SCHEMA IF NOT EXISTS ${schema};
   `;
 
-module.exports.destroy = (tablePrefix) => `DROP TABLE IF EXISTS ${tablePrefix}event_journal CASCADE;
-DROP TABLE IF EXISTS ${tablePrefix}snapshot_store CASCADE;`;
+  const eventTableQuery = `
+    CREATE TABLE IF NOT EXISTS ${schema ? schema + '.' : ''}${tablePrefix}${eventTable} (
+      ordering BIGSERIAL NOT NULL PRIMARY KEY,
+      persistence_key VARCHAR(255) NOT NULL,
+      sequence_nr BIGINT NOT NULL,
+      created_at BIGINT NOT NULL,
+      data JSONB NOT NULL,
+      is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+      tags TEXT ARRAY DEFAULT ARRAY[]::TEXT[],
+      CONSTRAINT ${tablePrefix}event_journal_uq UNIQUE (persistence_key, sequence_nr)
+    );
+  `;
+
+  const snapshotTableQuery = `
+    CREATE TABLE IF NOT EXISTS ${schema ? schema + '.' : ''}${tablePrefix}${snapshotTable} (
+      ordering BIGSERIAL NOT NULL PRIMARY KEY,
+      persistence_key VARCHAR(255) NOT NULL,
+      sequence_nr BIGINT NOT NULL,
+      created_at BIGINT NOT NULL,
+      data JSONB NOT NULL,
+      is_deleted BOOLEAN NOT NULL DEFAULT FALSE
+    );
+  `;
+
+  return [schema ? schemaQuery : null, eventTableQuery, snapshotTableQuery].filter(n => n).join('\n');
+};
+
+module.exports.destroy = (tablePrefix, schema = null, eventTable = 'event_journal', snapshotTable = 'snapshot_store') => {
+  const schemaQuery = `
+    DROP SCHEMA IF EXISTS ${schema} CASCADE;
+  `;
+
+  const eventTableQuery = `
+    DROP TABLE IF EXISTS ${schema ? schema + '.' : ''}${tablePrefix}${eventTable} CASCADE;
+  `;
+
+  const snapshotTableQuery = `
+    DROP TABLE IF EXISTS ${schema ? schema + '.' : ''}${tablePrefix}${snapshotTable} CASCADE;
+  `;
+
+  // IF the schema is dropped cascade, then it will by default also drop the tables on the schema
+  return [schema ? schemaQuery : null, eventTableQuery, snapshotTableQuery].filter(n => n).join('\n');
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nact-persistence-postgres",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -92,9 +92,9 @@
       }
     },
     "assert-options": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.1.3.tgz",
-      "integrity": "sha512-DXrZ5WkCv/igD+H8OmeUTl9k0pBhYSTdyA7DRZoSJERCzQ8Z2v85yDjkhYVnHUOeCXGfCNKaogRbLWQsIQbtpg=="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.6.2.tgz",
+      "integrity": "sha512-KP9S549XptFAPGYmLRnIjQBL4/Ry8Jx5YNLQZ/l+eejqbTidBMnw4uZSAsUrzBq/lgyqDYqxcTF7cOxZb9gyEw=="
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -1143,8 +1143,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -1402,11 +1401,6 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
-    },
-    "manakin": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/manakin/-/manakin-0.5.2.tgz",
-      "integrity": "sha512-pfDSB7QYoVg0Io4KMV9hhPoXpj6p0uBscgtyUSKCOFZe8bqgbpStfgnKIbF/ulnr6U3ICu4OqdyxAqBgOhZwBQ=="
     },
     "mime-db": {
       "version": "1.40.0",
@@ -4337,23 +4331,23 @@
       "dev": true
     },
     "pg": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.11.0.tgz",
-      "integrity": "sha512-YO4V7vCmEMGoF390LJaFaohWNKaA2ayoQOEZmiHVcAUF+YsRThpf/TaKCgSvsSE7cDm37Q/Cy3Gz41xiX/XjTw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.5.1.tgz",
+      "integrity": "sha512-9wm3yX9lCfjvA98ybCyw2pADUivyNWT/yIP4ZcDVpMN0og70BUWYEGXPCTAQdGTAqnytfRADb7NERrY1qxhIqw==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "0.1.3",
-        "pg-pool": "^2.0.4",
-        "pg-types": "~2.0.0",
-        "pgpass": "1.x",
-        "semver": "4.3.2"
+        "pg-connection-string": "^2.4.0",
+        "pg-pool": "^3.2.2",
+        "pg-protocol": "^1.4.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
       }
     },
     "pg-connection-string": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
+      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -4361,31 +4355,35 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-minify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.2.0.tgz",
-      "integrity": "sha512-T5oIs7KRDUghFrR73Dwqj6CSMJUQYZWqbPmDz312VcvZrTdG2SKy5AzSJJz4snZkLRMzXbNjhOZfqI/CH0IKPw=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.1.tgz",
+      "integrity": "sha512-ujanxJJB9CSDUvlAOshtjdKAywOPR2vY0a7D+vvgk5rbrYcthZA7TjpN+Z+UwZsz/G/bUexYDT6huE33vYVN0g=="
     },
     "pg-pool": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.6.tgz",
-      "integrity": "sha512-hod2zYQxM8Gt482q+qONGTYcg/qVcV32VHVPtktbBJs0us3Dj7xibISw0BAAXVMCzt8A/jhfJvpZaxUlqtqs0g=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.2.tgz",
+      "integrity": "sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA=="
     },
     "pg-promise": {
-      "version": "8.7.2",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-8.7.2.tgz",
-      "integrity": "sha512-vPKl8TFujeaQbSz4t+ltf6zAfBkKFZznWmoKeiNN7LHQLnj2toEomyCbKmDdFMfSIPmkJ3seQKC7AQhOV2bg2A==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.8.1.tgz",
+      "integrity": "sha512-xRW3PBopAAPlSmOutfpxwrd0i1wfiVoJjkRC2xYzwk0PwWGLEOVKoDEHX4VoqjfIJ+SEEiILy5B5nUVvXpFFVA==",
       "requires": {
-        "assert-options": "0.1.3",
-        "manakin": "0.5.2",
-        "pg": "7.11.0",
-        "pg-minify": "1.2.0",
-        "spex": "2.2.0"
+        "assert-options": "0.6.2",
+        "pg": "8.5.1",
+        "pg-minify": "1.6.1",
+        "spex": "3.0.2"
       }
     },
+    "pg-protocol": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.4.0.tgz",
+      "integrity": "sha512-El+aXWcwG/8wuFICMQjM5ZSAm6OWiJicFdNYo+VY3QP+8vI4SvLIWVe51PppTzMhikUJR+PsyIFKqfdXPz/yxA=="
+    },
     "pg-types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.0.1.tgz",
-      "integrity": "sha512-b7y6QM1VF5nOeX9ukMQ0h8a9z89mojrBHXfJeSug4mhL0YpxNBm83ot2TROyoAmX/ZOX3UbwVO4EbH7i1ZZNiw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "requires": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
@@ -4395,11 +4393,11 @@
       }
     },
     "pgpass": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
-      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
       "requires": {
-        "split": "^1.0.0"
+        "split2": "^3.1.1"
       }
     },
     "pify": {
@@ -4485,9 +4483,9 @@
       "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
     },
     "postgres-date": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.4.tgz",
-      "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
     },
     "postgres-interval": {
       "version": "1.2.0",
@@ -4703,8 +4701,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -4810,7 +4807,8 @@
     "semver": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -4875,16 +4873,28 @@
       "dev": true
     },
     "spex": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spex/-/spex-2.2.0.tgz",
-      "integrity": "sha512-iwBxqKe4ZKD+P/i/WdzWw5qxmerHvzVb29wQm4zwYaDPuwsTKjS7nbqt8OyBSLAi2q0ZFUN3F2b4erX0UwF0fA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-3.0.2.tgz",
+      "integrity": "sha512-ZNCrOso+oNv5P01HCO4wuxV9Og5rS6ms7gGAqugfBPjx1QwfNXJI3T02ldfaap1O0dlT1sB0Rk+mhDqxt3Z27w=="
     },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+    "split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "requires": {
-        "through": "2"
+        "readable-stream": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "sprintf-js": {
@@ -4936,7 +4946,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -5031,7 +5040,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -5114,8 +5124,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.2",


### PR DESCRIPTION
# Description
Allow for higher levels of configurability for the database schema and table names with full backwards compatibility.

This commit is for users to optionally place their event journal and snapshot store in a schema that is not the default Postgres "public" schema.  This enhances security as well as authentication.

Additionally, users can now configure the name of the event_journal and snapshot_store in addition to using a prefix.  This is useful for when users need nomenclature to match their business domains.

## Overview
- Allows for backwards compatibility with previous version
- Allows for a Postgres Schema to be used
- Allows for Table Names to be customized

## Update Documentation
The Postgres Persistence constructor can now take additional configuration options:
- `schema` :  The Postgres Schema to implement
- `eventTable`: The Table name for the event journal
- `snapshotTable`: The Table name for the snapshot store.

## Rationale
I needed to rename the tables and use multiple instances of the Postgres Persistence connections as well as move the default tables out of the public schema.  This PR is based on the conversation from Discord. 
 
